### PR TITLE
ci: relase luzid for linux and macos via tags

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,8 +1,9 @@
 name: 'Luzid: Release Linux'
 on:
-  push:
-    tags:
-      - "linux-v*.*.*"
+  # push:
+  #   tags:
+  #     - "linux-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   release-linux:

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,110 @@
+name: 'Luzid: Release Linux'
+on:
+  push:
+    tags:
+      - "linux-v*.*.*"
+
+jobs:
+  release-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 200
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout Luzid
+        uses: actions/checkout@v4
+        with:
+          repository: luzid-app/luzid
+          path: luzid
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Checkout Solana and Install Deps
+        uses: ./luzid/.github/actions/checkout-solana-and-install-deps
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-personal-access-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'build-release-linux'
+          workspaces: |
+            luzid -> target
+            luzid -> build
+          cache-targets: true
+          cache-all-crates: true
+          cache-on-failure: true
+
+      - name: Install Flutter build Deps
+        run: sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+        working-directory: luzid
+        shell: bash
+
+      - name: Install Prost
+        run: cargo install protoc-gen-prost
+        working-directory: luzid
+        shell: bash
+
+      - name: Cargo Build
+        run: make ci-build-linux-release
+        working-directory: luzid
+        shell: bash
+        env:
+          RINF: 1
+
+      - name: Flutter Build
+        run: make ci-flutter-build-linux-release
+        working-directory: luzid
+        shell: bash
+        env:
+          RINF: 1
+
+      ## Prepare Headless Asset
+      - name: Show Headless Asset
+        run: ls -la target/release
+        working-directory: luzid
+        shell: bash
+
+      - name: Move Headless Asset to Luzid Root
+        run: mv target/release/lzd lzd
+        working-directory: luzid
+        shell: bash
+
+      - name: Packup Headless Asset
+        run: |
+          tar czvf lzd.tar.gz lzd
+        working-directory: luzid
+        shell: bash
+
+      ## Prepare Flutter Assets
+      - name: Show Flutter Assets
+        run: ls -la build/linux/x64/release/bundle
+        working-directory: luzid
+        shell: bash
+
+      - name: Move Flutter Assets to Luzid Root
+        run: mv build/linux/x64/release/bundle luzid-bundle
+        working-directory: luzid
+        shell: bash
+
+      - name: Packup Flutter Assets
+        run: |
+          tar czvf luzid.tar.gz  luzid-bundle
+        working-directory: luzid
+        shell: bash
+
+      ## Publish Release
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            luzid/lzd.tar.gz
+            luzid/luzid.tar.gz
+          body: ${{ github.event.head_commit.message }}
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,9 +1,8 @@
 name: 'Luzid: Release Linux'
 on:
-  # push:
-  #   tags:
-  #     - "linux-v*.*.*"
-  workflow_dispatch:
+  push:
+    tags:
+      - "linux-v*.*.*"
 
 jobs:
   release-linux:
@@ -67,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Move Headless Asset to Luzid Root
-        run: mv target/release/luzid lzd
+        run: mv target/release/luzid_server lzd
         working-directory: luzid
         shell: bash
 

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Move Headless Asset to Luzid Root
-        run: mv target/release/lzd lzd
+        run: mv target/release/luzid lzd
         working-directory: luzid
         shell: bash
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - "macos-v*.*.*"
-  workflow_dispatch:
 
 jobs:
   release-macos-m1:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "macos-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   release-macos-m1:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,83 @@
+name: 'Luzid: Release MacOS'
+on:
+  push:
+    tags:
+      - "macos-v*.*.*"
+
+jobs:
+  release-macos-m1:
+    runs-on: macos-14
+    timeout-minutes: 90
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout Luzid
+        uses: actions/checkout@v4
+        with:
+          repository: luzid-app/luzid
+          path: luzid
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Checkout Solana and Install Deps
+        uses: ./luzid/.github/actions/checkout-solana-and-install-deps
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-personal-access-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'build-release-macos-m1'
+          workspaces: |
+            luzid -> build/macos/Build/Intermediates.noindex/Pods.build/Release/rinf.build
+          cache-targets: true
+          cache-all-crates: true
+          cache-on-failure: true
+
+      - name: Flutter create Macos (to get xcodeproj)
+        run: flutter create --platforms=macos .
+        working-directory: luzid
+        shell: bash
+
+      - name: Rinf Message Generation
+        run: dart run rinf message
+        working-directory: luzid
+        shell: bash
+
+      - name: Flutter Build
+        run: make ci-flutter-build-macos-release
+        working-directory: luzid
+        shell: bash
+        env:
+          RINF: 1
+
+      ## Prepare Flutter Assets
+      - name: Show Fultter Assets
+        run: ls -la build/macos/Build
+        working-directory: luzid
+
+      - name: Move Flutter Assets to Luzid Root
+        run: mv build/macos/Build/Products/Release/luzid.app Luzid.app
+        working-directory: luzid
+        shell: bash
+
+      - name: Packup Flutter Assets
+        run: |
+          tar czvf luzid.tar.gz Luzid.app
+        working-directory: luzid
+        shell: bash
+
+      ## Publish Release
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            luzid/luzid.tar.gz
+          body: ${{ github.event.head_commit.message }}
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}


### PR DESCRIPTION
## Summary

Add github workflows to release luzid for Linux or Macos from this repo.

## Details

The SDK source is included in the release even though it is not necessarily related to it, but
there is no way to prevent this currently.

Github workflows release:

### Linux

- flutter bundle as `luzid`
- headless as `lzd`

### Macos

- flutter app as `Luzid.app`

Release is triggered by pushing a tag of the following format for linux/macos respectively:

- `linux-v*.*.*`
- `macos-v*.*.*`

