### PR TITLE
chore: release workflows

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,8 +1,9 @@
 name: 'Luzid: Release Linux'
 on:
   push:
-    tags:
-      - "linux-v*.*.*"
+    brances: [ ci-release-build-workflows  ]
+      # tags:
+      #   - "linux-v*.*.*"
 
 jobs:
   release-linux:
@@ -17,6 +18,7 @@ jobs:
         with:
           repository: luzid-app/luzid
           path: luzid
+          ref: feat/separate-pieces
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Checkout Solana and Install Deps
@@ -56,12 +58,12 @@ jobs:
 
       ## Prepare Rust Backend Asset
       - name: Show Rust Backend Asset
-        run: ls -la target/release
+        run: ls -la rs/target/release
         working-directory: luzid
         shell: bash
 
       - name: Move Rust Backend Asset to Luzid Root
-        run: mv target/release/luzid luzid
+        run: mv rs/target/release/luzid luzid
         working-directory: luzid
         shell: bash
 
@@ -73,18 +75,18 @@ jobs:
 
       ## Prepare Flutter Assets
       - name: Show Flutter Assets
-        run: ls -la build/linux/x64/release/bundle
+        run: ls -la ui/build/linux/x64/release/bundle
         working-directory: luzid
         shell: bash
 
       - name: Move Flutter Assets to Luzid Root
-        run: mv build/linux/x64/release/bundle luzid-bundle
+        run: mv ui/build/linux/x64/release/bundle luzidui
         working-directory: luzid
         shell: bash
 
       - name: Packup Flutter Assets
         run: |
-          tar czvf luzidui.tar.gz  luzid-bundle
+          tar czvf luzidui.tar.gz luzidui
         working-directory: luzid
         shell: bash
 
@@ -102,12 +104,17 @@ jobs:
    #    run: |
    #      echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
-   #  - name: Release Assets
-   #    uses: softprops/action-gh-release@v1
-   #    with:
-   #      files: |
-   #        luzid/luzid.tar.gz
-   #        luzid/luzidui.tar.gz
-   #      body: ${{ github.event.head_commit.message }}
-   #      draft: true
-   #      tag_name: ${{ env.TAG_NAME }}
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=test-release-linux" >> $GITHUB_ENV
+
+      - name: Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            luzid/luzid.tar.gz
+            luzid/luzidui.tar.gz
+          body: ${{ github.event.head_commit.message }}
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,9 +1,8 @@
 name: 'Luzid: Release Linux'
 on:
   push:
-    brances: [ ci-release-build-workflows  ]
-      # tags:
-      #   - "linux-v*.*.*"
+    tags:
+      - "linux-v*.*.*"
 
 jobs:
   release-linux:
@@ -18,7 +17,6 @@ jobs:
         with:
           repository: luzid-app/luzid
           path: luzid
-          ref: feat/separate-pieces
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Checkout Solana and Install Deps
@@ -99,15 +97,10 @@ jobs:
         shell: bash
 
       ## Publish Release
-   #  - name: Resolve version
-   #    id: vars
-   #    run: |
-   #      echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-
       - name: Resolve version
         id: vars
         run: |
-          echo "TAG_NAME=test-release-linux" >> $GITHUB_ENV
+          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Release Assets
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -29,8 +29,7 @@ jobs:
         with:
           shared-key: 'build-release-linux'
           workspaces: |
-            luzid -> target
-            luzid -> build
+            luzid/rs -> target
           cache-targets: true
           cache-all-crates: true
           cache-on-failure: true
@@ -49,30 +48,26 @@ jobs:
         run: make ci-build-linux-release
         working-directory: luzid
         shell: bash
-        env:
-          RINF: 1
 
       - name: Flutter Build
         run: make ci-flutter-build-linux-release
         working-directory: luzid
         shell: bash
-        env:
-          RINF: 1
 
-      ## Prepare Headless Asset
-      - name: Show Headless Asset
+      ## Prepare Rust Backend Asset
+      - name: Show Rust Backend Asset
         run: ls -la target/release
         working-directory: luzid
         shell: bash
 
-      - name: Move Headless Asset to Luzid Root
-        run: mv target/release/luzid_server lzd
+      - name: Move Rust Backend Asset to Luzid Root
+        run: mv target/release/luzid luzid
         working-directory: luzid
         shell: bash
 
-      - name: Packup Headless Asset
+      - name: Packup Rust Backend Asset
         run: |
-          tar czvf lzd.tar.gz lzd
+          tar czvf luzid.tar.gz luzid
         working-directory: luzid
         shell: bash
 
@@ -89,22 +84,30 @@ jobs:
 
       - name: Packup Flutter Assets
         run: |
-          tar czvf luzid.tar.gz  luzid-bundle
+          tar czvf luzidui.tar.gz  luzid-bundle
         working-directory: luzid
         shell: bash
 
-      ## Publish Release
-      - name: Resolve version
-        id: vars
-        run: |
-          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: Show Release Backend Asset
+        run: ls -la luzid/luzid.tar.gz
+        shell: bash
 
-      - name: Release Assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            luzid/lzd.tar.gz
-            luzid/luzid.tar.gz
-          body: ${{ github.event.head_commit.message }}
-          draft: true
-          tag_name: ${{ env.TAG_NAME }}
+      - name: Show Release Flutter UI Asset
+        run: ls -la luzid/luzidui.tar.gz
+        shell: bash
+
+      ## Publish Release
+   #  - name: Resolve version
+   #    id: vars
+   #    run: |
+   #      echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+
+   #  - name: Release Assets
+   #    uses: softprops/action-gh-release@v1
+   #    with:
+   #      files: |
+   #        luzid/luzid.tar.gz
+   #        luzid/luzidui.tar.gz
+   #      body: ${{ github.event.head_commit.message }}
+   #      draft: true
+   #      tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -116,5 +116,6 @@ jobs:
             luzid/luzid.tar.gz
             luzid/luzidui.tar.gz
           body: ${{ github.event.head_commit.message }}
+
           draft: true
           tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -113,12 +113,7 @@ jobs:
 
       - name: Packup Flutter Assets
         run: |
-          tar czvf LuzidUI.tar.gz LuzidUI.app
-        working-directory: luzid
-        shell: bash
-
-      - name: Show Flutter Assets
-        run: ls -la LuzidUI.tar.gz
+          tar czvf LuzidUI.app.tar.gz LuzidUI.app
         working-directory: luzid
         shell: bash
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,9 +1,8 @@
 name: 'Luzid: Release MacOS'
 on:
   push:
-    brances: [ ci-release-build-workflows  ]
-      # tags:
-      #   - "macos-v*.*.*"
+    tags:
+      - "macos-v*.*.*"
 
 jobs:
   release-macos-m1:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           repository: luzid-app/luzid
           path: luzid
-          ref: feat/separate-pieces
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Checkout Solana and Install Deps
@@ -129,15 +128,10 @@ jobs:
         shell: bash
 
       ## Publish Release
-      #- name: Resolve version
-      #  id: vars
-      #  run: |
-      #    echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-
       - name: Resolve version
         id: vars
         run: |
-          echo "TAG_NAME=test-release" >> $GITHUB_ENV
+          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Release Assets
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,8 +1,9 @@
 name: 'Luzid: Release MacOS'
 on:
   push:
-    tags:
-      - "macos-v*.*.*"
+    brances: [ ci-release-build-workflows  ]
+      # tags:
+      #   - "macos-v*.*.*"
 
 jobs:
   release-macos-m1:
@@ -17,6 +18,7 @@ jobs:
         with:
           repository: luzid-app/luzid
           path: luzid
+          ref: feat/separate-pieces
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Checkout Solana and Install Deps
@@ -27,118 +29,128 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: 'build-release-macos-m1'
+          shared-key: 'build-release-macos-cache-bust-000'
           workspaces: |
-            luzid -> build/macos/Build/Intermediates.noindex/Pods.build/Release/rinf.build
+            luzid/rs -> target
           cache-targets: true
           cache-all-crates: true
           cache-on-failure: true
 
-      - name: Flutter create Macos (to get xcodeproj)
-        run: flutter create --platforms=macos .
+      ## Rust Backend
+      - name: Add x86_64 Rust Target
+        run: rustup target add x86_64-apple-darwin
+        shell: bash
+
+      ### X86_64 Build
+      - name: Cargo Build X86_64
+        run: make ci-build-macos-x86_64-release
         working-directory: luzid
         shell: bash
 
-      - name: Rinf Message Generation
-        run: dart run rinf message
+      - name: Add x86_64 Rust Target
+        run: rustup target add x86_64-apple-darwin
+        shell: bash
+
+      - name: Show Rust Backend X86_64 Asset
+        run: ls -la target/x86_64-apple-darwin/release
         working-directory: luzid
+        shell: bash
+
+      - name: Move Rust Backend X86_64 Asset to Luzid Root
+        run: mv target/x86_64-apple-darwin/release/luzid luzid
+        working-directory: luzid
+        shell: bash
+
+      - name: Packup Rust Backend X86_64 Asset
+        run: |
+          tar czvf luzid_x86_64-apple-darwin.tar.gz luzid
+        working-directory: luzid
+        shell: bash
+
+      - name: Remove x86_64 Assets
+        run: rm -rf luzid
+        working-directory: luzid
+        shell: bash
+
+      ### Arm Build
+      - name: Cargo Build Arm
+        run: make ci-build-macos-arm-release
+        working-directory: luzid
+        shell: bash
+
+      - name: Show Rust Backend Arm Asset
+        run: ls -la target/release
+        working-directory: luzid
+        shell: bash
+
+      - name: Move Rust Backend Arm Asset to Luzid Root
+        run: mv target/release/luzid luzid
+        working-directory: luzid
+        shell: bash
+
+      - name: Packup Rust Backend Arm Asset
+        run: |
+          tar czvf luzid_aarch64-apple-darwin.tar.gz luzid
+        working-directory: luzid
+        shell: bash
+
+      ## Flutter UI
+      - name: Flutter create Macos (to get xcodeproj)
+        run: flutter create --platforms=macos .
+        working-directory: luzid/ui
         shell: bash
 
       - name: Flutter Build
         run: make ci-flutter-build-macos-release
         working-directory: luzid
         shell: bash
-        env:
-          RINF: 1
 
-      ## Prepare Flutter Assets
+      ### Prepare Flutter Assets
       - name: Show Flutter Assets
         run: ls -la build/macos/Build
         working-directory: luzid
 
       - name: Move Flutter Assets to Luzid Root
-        run: mv build/macos/Build/Products/Release/luzid.app Luzid.app
+        run: mv ui/build/macos/Build/Products/Release/luzid.app LuzidUI.app
         working-directory: luzid
         shell: bash
 
       - name: Packup Flutter Assets
         run: |
-          tar czvf luzid.app.tar.gz Luzid.app
+          tar czvf LuzidUI.tar.gz LuzidUI.app
         working-directory: luzid
         shell: bash
 
-
-      ## Build and Prepare Headless Assets
-      - name: Add x86_64 Rust Target
-        run: rustup target add x86_64-apple-darwin
-        shell: bash
-
-      ## X86_64 Build
-      - name: Cargo Build X86_64
-        run: make ci-build-macos-x86_64-release
-        working-directory: luzid
-        shell: bash
-        env:
-          RINF: 1
-
-      - name: Show Headless X86_64 Asset
-        run: ls -la target/x86_64-apple-darwin/release
+      - name: Show Flutter Assets
+        run: ls -la LuzidUI.tar.gz
         working-directory: luzid
         shell: bash
 
-      - name: Move Headless X86_64 Asset to Luzid Root
-        run: mv target/x86_64-apple-darwin/release/luzid_server lzd
-        working-directory: luzid
+      - name: Show Release x86_64 Asset
+        run: ls -la luzid/luzid_x86_64-apple-darwin.tar.gz
         shell: bash
 
-      - name: Packup Headless X86_64 Asset
-        run: |
-          tar czvf lzd_x86_64-apple-darwin.tar.gz lzd
-        working-directory: luzid
+      - name: Show Release Arm Asset
+        run: ls -la luzid/luzid_aarch64-apple-darwin.tar.gz
         shell: bash
 
-      - name: Remove x86_64 Assets
-        run: rm -rf lzd
-        working-directory: luzid
-        shell: bash
-
-      ## Arm Build
-      - name: Cargo Build Arm
-        run: make ci-build-macos-arm-release
-        working-directory: luzid
-        shell: bash
-        env:
-          RINF: 1
-
-      - name: Show Headless Arm Asset
-        run: ls -la target/release
-        working-directory: luzid
-        shell: bash
-
-      - name: Move Headless Arm Asset to Luzid Root
-        run: mv target/release/luzid_server lzd
-        working-directory: luzid
-        shell: bash
-
-      - name: Packup Headless Arm Asset
-        run: |
-          tar czvf lzd_aarch64-apple-darwin.tar.gz lzd
-        working-directory: luzid
+      - name: Show Release Fultter UI Asset
+        run: ls -la luzid/LuzidUI.app.tar.gz
         shell: bash
 
       ## Publish Release
-      - name: Resolve version
-        id: vars
-        run: |
-          echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+      #- name: Resolve version
+      #  id: vars
+      #  run: |
+      #    echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
-      - name: Release Assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            luzid/lzd_x86_64-apple-darwin.tar.gz
-            luzid/lzd_aarch64-apple-darwin.tar.gz
-            luzid/luzid.app.tar.gz
-          body: ${{ github.event.head_commit.message }}
-          draft: true
-          tag_name: ${{ env.TAG_NAME }}
+      #- name: Release Assets
+      #  uses: softprops/action-gh-release@v1
+      #  with:
+      #    files: |
+      #      luzid/luzid_x86_64-apple-darwin.tar.gz
+      #      luzid/luzid_aarch64-apple-darwin.tar.gz
+      #      luzid/LuzidUI.app.tar.gz
+      #    body: ${{ github.event.head_commit.message }}
+      #    draft: true
+      #    tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -134,7 +134,7 @@ jobs:
         run: ls -la luzid/luzid_aarch64-apple-darwin.tar.gz
         shell: bash
 
-      - name: Show Release Fultter UI Asset
+      - name: Show Release Flutter UI Asset
         run: ls -la luzid/LuzidUI.app.tar.gz
         shell: bash
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -47,17 +47,13 @@ jobs:
         working-directory: luzid
         shell: bash
 
-      - name: Add x86_64 Rust Target
-        run: rustup target add x86_64-apple-darwin
-        shell: bash
-
       - name: Show Rust Backend X86_64 Asset
-        run: ls -la target/x86_64-apple-darwin/release
+        run: ls -la rs/target/x86_64-apple-darwin/release
         working-directory: luzid
         shell: bash
 
       - name: Move Rust Backend X86_64 Asset to Luzid Root
-        run: mv target/x86_64-apple-darwin/release/luzid luzid
+        run: mv rs/target/x86_64-apple-darwin/release/luzid luzid
         working-directory: luzid
         shell: bash
 
@@ -68,7 +64,7 @@ jobs:
         shell: bash
 
       - name: Remove x86_64 Assets
-        run: rm -rf luzid
+        run: rm -f luzid
         working-directory: luzid
         shell: bash
 
@@ -79,12 +75,12 @@ jobs:
         shell: bash
 
       - name: Show Rust Backend Arm Asset
-        run: ls -la target/release
+        run: ls -la rs/target/release
         working-directory: luzid
         shell: bash
 
       - name: Move Rust Backend Arm Asset to Luzid Root
-        run: mv target/release/luzid luzid
+        run: mv rs/target/release/luzid luzid
         working-directory: luzid
         shell: bash
 
@@ -107,7 +103,7 @@ jobs:
 
       ### Prepare Flutter Assets
       - name: Show Flutter Assets
-        run: ls -la build/macos/Build
+        run: ls -la ui/build/macos/Build
         working-directory: luzid
 
       - name: Move Flutter Assets to Luzid Root
@@ -144,13 +140,18 @@ jobs:
       #  run: |
       #    echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
-      #- name: Release Assets
-      #  uses: softprops/action-gh-release@v1
-      #  with:
-      #    files: |
-      #      luzid/luzid_x86_64-apple-darwin.tar.gz
-      #      luzid/luzid_aarch64-apple-darwin.tar.gz
-      #      luzid/LuzidUI.app.tar.gz
-      #    body: ${{ github.event.head_commit.message }}
-      #    draft: true
-      #    tag_name: ${{ env.TAG_NAME }}
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=test-release" >> $GITHUB_ENV
+
+      - name: Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            luzid/luzid_x86_64-apple-darwin.tar.gz
+            luzid/luzid_aarch64-apple-darwin.tar.gz
+            luzid/LuzidUI.app.tar.gz
+          body: ${{ github.event.head_commit.message }}
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}


### PR DESCRIPTION
## Summary

Updated release workflows to account for repo restructuring.

## Next

Once we finish the final feature in Luzid that requires changes to the SDK we should finalize
at least the Dart SDK and start using [melos](https://github.com/invertase/melos) to be able to
publish the SDK to pub.dev in order to avoid having to manually build the protos in order to
build our Flutter app.

At that point it will be much easier to add windows support.

