### PR TITLE
feat: add workspace watch changed sub to dart SDK

### DIFF
--- a/dart/luzid-grpc-client/lib/src/client/workspace.dart
+++ b/dart/luzid-grpc-client/lib/src/client/workspace.dart
@@ -78,6 +78,20 @@ class WorkspacePersistClient {
 }
 
 // -----------------
+// WorkspaceWatchChangedClient
+// -----------------
+class WorkspaceWatchChangedClient {
+  final WorkspaceWatchChangedSubClient _client;
+
+  WorkspaceWatchChangedClient(ClientChannelBase channel)
+      : _client = WorkspaceWatchChangedSubClient(channel);
+
+  Stream<WorkspaceWatchChanged> subWorkspaceWatchChanged() {
+    return _client.subWorkspaceWatchChanged(Empty());
+  }
+}
+
+// -----------------
 // Consolidated WorkspaceClient
 // -----------------
 class WorkspaceClient {
@@ -85,12 +99,14 @@ class WorkspaceClient {
   final WorkspaceCloneClient _cloneWorkspaceClient;
   final WorkspaceWatchClient _watchWorkspaceClient;
   final WorkspacePersistClient _persistWorkspaceClient;
+  final WorkspaceWatchChangedClient _workspaceWatchChangedClient;
 
   WorkspaceClient(ClientChannelBase channel)
       : _getWorkspaceClient = WorkspaceGetClient(channel),
         _cloneWorkspaceClient = WorkspaceCloneClient(channel),
         _watchWorkspaceClient = WorkspaceWatchClient(channel),
-        _persistWorkspaceClient = WorkspacePersistClient(channel);
+        _persistWorkspaceClient = WorkspacePersistClient(channel),
+        _workspaceWatchChangedClient = WorkspaceWatchChangedClient(channel);
 
   Future<GetWorkspaceResponse> getWorkspace(GetWorkspaceRequest request) {
     return _getWorkspaceClient.getWorkspace(request);
@@ -126,5 +142,9 @@ class WorkspaceClient {
 
   Future<ListWorkspacesResponse> listWorkspaces() {
     return _persistWorkspaceClient.listWorkspaces();
+  }
+
+  Stream<WorkspaceWatchChanged> subWorkspaceWatchChanged() {
+    return _workspaceWatchChangedClient.subWorkspaceWatchChanged();
   }
 }

--- a/dart/luzid-grpc/lib/luzid_grpc.dart
+++ b/dart/luzid-grpc/lib/luzid_grpc.dart
@@ -96,6 +96,10 @@ export 'proto/subs/validator_stats_sub.pb.dart';
 export 'proto/subs/validator_stats_sub.pbgrpc.dart';
 export 'proto/subs/validator_stats_sub.pbjson.dart';
 
+export 'proto/subs/workspace_watch_changed_sub.pb.dart';
+export 'proto/subs/workspace_watch_changed_sub.pbgrpc.dart';
+export 'proto/subs/workspace_watch_changed_sub.pbjson.dart';
+
 // -----------------
 // Types
 // -----------------

--- a/dart/luzid-sdk/lib/src/api/workspace.dart
+++ b/dart/luzid-sdk/lib/src/api/workspace.dart
@@ -2,7 +2,8 @@ import 'package:luzid_grpc/luzid_grpc.dart';
 import 'package:luzid_grpc_client/luzid_grpc_client.dart';
 import 'package:luzid_sdk/src/core/utils.dart';
 
-export 'package:luzid_grpc/luzid_grpc.dart' show RpcWorkspace;
+export 'package:luzid_grpc/luzid_grpc.dart'
+    show RpcWorkspace, WorkspaceWatchChanged;
 
 class LuzidWorkspace {
   final LuzidGrpcClient client;
@@ -117,6 +118,12 @@ class LuzidWorkspace {
   Future<List<String>> listWorkspaces() async {
     final res = await client.workspace.listWorkspaces();
     return unwrap(res, 'Luzid workspace.listWorkspaces').workspaceRoots;
+  }
+
+  /// Subscribes to workspaces being watched or unwatched.
+  /// The emitted type includes the workspace root and the watch state.
+  Stream<WorkspaceWatchChanged> subWorkspaceWatchChanged() {
+    return client.workspace.subWorkspaceWatchChanged();
   }
 }
 


### PR DESCRIPTION
## Summary

This subscription is needed for Luzid UI to update preconfigured workspaces correctly.

NOTE: The TypeScript SDK did not add this feature
