### PR TITLE
feat: support custom grpc protocol and add cluster label

### DIFF
--- a/ts/packages/luzid-grpc-client/src/grpc-client.ts
+++ b/ts/packages/luzid-grpc-client/src/grpc-client.ts
@@ -15,6 +15,7 @@ const DEFAULT_GRPC_SERVER_HOST = 'localhost'
 
 export type LuzidGrpcClientOpts = {
   host?: string
+  protocol?: 'http' | 'https'
   port?: number
 }
 
@@ -34,7 +35,8 @@ export class LuzidGrpcClient {
   constructor(opts?: LuzidGrpcClientOpts) {
     const host = opts?.host ?? DEFAULT_GRPC_SERVER_HOST
     const port = opts?.port ?? DEFAULT_GRPC_SERVER_PORT
-    const url = `${host}:${port}`
+    const protocol = opts?.protocol ?? 'http'
+    const url = `${protocol}://${host}:${port}`
     this.channel = createChannel(url)
   }
 

--- a/ts/packages/luzid-sdk/src/api-types/cluster.ts
+++ b/ts/packages/luzid-sdk/src/api-types/cluster.ts
@@ -65,6 +65,21 @@ export class Cluster implements LuzidCluster {
     }
   }
 
+  get label(): String {
+    switch (this.grpcCluster) {
+      case GrpcCluster.Development:
+        return 'Development'
+      case GrpcCluster.Testnet:
+        return 'Testnet'
+      case GrpcCluster.MainnetBeta:
+        return 'Mainnet Beta'
+      case GrpcCluster.Devnet:
+        return 'Devnet'
+      default:
+        throw new Error(`Unknown cluster: ${this.grpcCluster}`)
+    }
+  }
+
   toJSON() {
     return clusterToJSON(this.grpcCluster)
   }


### PR DESCRIPTION
- fix: support providing a protocol to GRPC client, default to http
- sdk: expose label on cluster
